### PR TITLE
Script to automate version updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ To update, make these changes to the file at Formula/ddev-live.rb:
 
 6. Confirm that the update works (`brew upgrade ddev-live`)
 
+The steps 1, 2, 3 and 4 are automated [by a script](./hack/update_formula.bash), example usage:
+```
+$ version=0.7.0 ./hack/update_formula.bash
+```

--- a/hack/update_formula.bash
+++ b/hack/update_formula.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script automates updating of the brew formula file.
+#
+# example:
+# $ version=0.6.0 ./hack/update_formula.bash
+
+set -euo pipefail
+
+version=${version:-0.7.0}
+
+git pull
+
+bucket=downloads.ddev.com/ddev-live-cli/v
+sha=$(gsutil cat gs://${bucket}${version}/brew/ddev-live.zip.sha256.txt | awk 'NR==1{print($1)}')
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+file="$dir/../Formula/ddev-live.rb"
+
+sed -i 's|\(url "https://'"${bucket}\)"'.*\(/brew/ddev-live.zip\)|\1'"${version}"'\2|' "${file}"
+sed -i 's|\(version "\).*"|\1'"${version}"'"|' "${file}"
+sed -i 's|\(sha256 "\).*"|\1'"${sha}"'"|' "${file}"
+
+git commit -am "Bumping version to v${version}"
+echo "verify changes and perform 'git push origin master'"


### PR DESCRIPTION
Current procedure to release new ddev-live-client homebrew version is pretty manual, I would like to propose some automation to make this easier.

https://github.com/drud/homebrew-ddev-live/commit/caf317b930d8147a89081ce42b43677a886b8dc0 was generated using this script and I think it matches the README.md and previous commits in the repo.